### PR TITLE
[docker] Ditch argon and use latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from node:argon
+from node:latest
 
 RUN mkdir /deps
 ADD ./package.json /deps


### PR DESCRIPTION
Since we're gonna be utilizing most of
  es2015 features, then let's use the latest
  build.

Signed-off-by: Elizar Pepino <jupenz@gmail.com>